### PR TITLE
 Fix a bug for page summary failure.

### DIFF
--- a/src/content-script/compenents/PageSummary.tsx
+++ b/src/content-script/compenents/PageSummary.tsx
@@ -52,7 +52,7 @@ function PageSummary(props: Props) {
 
     const pageComments = await getPageSummaryComments()
     const pageContent = await getPageSummaryContntent()
-    const article = pageComments ? pageComments : pageContent
+    const article = pageComments && pageComments.content ? pageComments : pageContent
 
     const title = article?.title || document.title || ''
     const description =


### PR DESCRIPTION
pagecomment can be an empty object like { "title": null, "content": null, "description": null } and it bypasses page summary.

Here is a website to test: http://www.paulgraham.com/hwh.html#f9n