### PR TITLE
fix: adjust layout for Kagi

### DIFF
--- a/src/content-script/search-engine-configs.ts
+++ b/src/content-script/search-engine-configs.ts
@@ -81,7 +81,7 @@ export const config: Record<string, SearchEngine> = {
   },
   kagi: {
     inputQuery: ["input[name='q']"],
-    sidebarContainerQuery: ['.right-content-box._0_right_sidebar'],
+    sidebarContainerQuery: ['.right-content-box > ._0_right_sidebar'],
     appendContainerQuery: ['#_0_app_content'],
     contentContainerQuery: [],
     siteName: 'kagi',


### PR DESCRIPTION
I noticed that the layout on Kagi appears distorted, perhaps due to a modification in the HTML structure by Kagi. So, I took the initiative to make it more presentable.


## Before

![CleanShot 2023-06-08 at 11 29 53](https://github.com/sparticleinc/chatgpt-google-summary-extension/assets/38032437/703a3512-9a29-45eb-ae65-c3eda50c328e)


## After

![CleanShot 2023-06-08 at 11 29 39](https://github.com/sparticleinc/chatgpt-google-summary-extension/assets/38032437/3ac4ca9e-4052-424e-a394-84c05f1d27f4)
