### PR TITLE
Add custom api path support

### DIFF
--- a/src/background/providers/openai.ts
+++ b/src/background/providers/openai.ts
@@ -24,6 +24,7 @@ export class OpenAIProvider implements Provider {
 
     const gptModel = config.configs[ProviderType.GPT3]?.model ?? DEFAULT_MODEL
     const apiHost = config.configs[ProviderType.GPT3]?.apiHost || DEFAULT_API_HOST
+    const apiPath = config.configs[ProviderType.GPT3]?.apiPath
 
     let url = ''
     let reqParams = {
@@ -35,10 +36,10 @@ export class OpenAIProvider implements Provider {
       // temperature: 0.5,
     }
     if (gptModel === 'text-davinci-003') {
-      url = `https://${apiHost}/v1/completions`
+      url = `https://${apiHost}${apiPath || '/v1/completions'}`
       reqParams = { ...reqParams, ...{ prompt: this.buildPrompt(params.prompt) } }
     } else {
-      url = `https://${apiHost}/v1/chat/completions`
+      url = `https://${apiHost}${apiPath || '/v1/chat/completions'}`
       reqParams = { ...reqParams, ...{ messages: this.buildMessages(params.prompt) } }
     }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -60,7 +60,7 @@ const userConfigWithDefaultValue: {
   pageSummaryEnable: true,
   pageSummaryWhitelist: '',
   pageSummaryBlacklist: '',
-  continueConversation: true
+  continueConversation: true,
 }
 
 export type UserConfig = typeof userConfigWithDefaultValue
@@ -84,6 +84,7 @@ interface GPT3ProviderConfig {
   model: string
   apiKey: string
   apiHost: string
+  apiPath: string | undefined
 }
 
 export interface ProviderConfigs {

--- a/src/options/ProviderSelect.tsx
+++ b/src/options/ProviderSelect.tsx
@@ -15,6 +15,7 @@ const ConfigPanel: FC<ConfigProps> = ({ config, models }) => {
   const [tab, setTab] = useState<ProviderType>(isSafari ? ProviderType.GPT3 : config.provider)
   const { bindings: apiKeyBindings } = useInput(config.configs[ProviderType.GPT3]?.apiKey ?? '')
   const { bindings: apiHostBindings } = useInput(config.configs[ProviderType.GPT3]?.apiHost ?? '')
+  const { bindings: apiPathBindings } = useInput(config.configs[ProviderType.GPT3]?.apiPath ?? '')
   const [model, setModel] = useState(config.configs[ProviderType.GPT3]?.model ?? models[0])
   const { setToast } = useToasts()
 
@@ -34,15 +35,26 @@ const ConfigPanel: FC<ConfigProps> = ({ config, models }) => {
     let apiHost = apiHostBindings.value || ''
     apiHost = apiHost.replace(/^http(s)?:\/\//, '')
 
+    const apiPath = apiPathBindings.value || ''
+
     await saveProviderConfigs(tab, {
       [ProviderType.GPT3]: {
         model,
         apiKey: apiKeyBindings.value,
         apiHost: apiHost,
+        apiPath: apiPath,
       },
     })
     setToast({ text: 'Changes saved', type: 'success' })
-  }, [apiHostBindings.value, apiKeyBindings.value, model, models, setToast, tab])
+  }, [
+    apiHostBindings.value,
+    apiKeyBindings.value,
+    apiPathBindings.value,
+    model,
+    models,
+    setToast,
+    tab,
+  ])
 
   useEffect(() => {
     console.log('config', config)
@@ -82,6 +94,14 @@ const ConfigPanel: FC<ConfigProps> = ({ config, models }) => {
                       scale={2 / 3}
                       clearable
                       {...apiHostBindings}
+                    />
+                    <Input
+                      htmlType="text"
+                      placeholder="/v1/chat/completions"
+                      label="API Path"
+                      scale={2 / 3}
+                      clearable
+                      {...apiPathBindings}
                     />
                     <Aselect
                       defaultValue={model}
@@ -142,7 +162,7 @@ function ProviderSelect() {
     'gpt-3.5-turbo-0301',
     'gpt-3.5-turbo-0613',
     'gpt-3.5-turbo-16k',
-    'text-davinci-003'
+    'text-davinci-003',
     // 'text-curie-001',
     // 'text-babbage-001',
     // 'text-ada-001',


### PR DESCRIPTION
There are some 3rd party Chat API providers, which provide API with different API Path from OpenAI, for example, the API Path of OpenAI is `/v1/chat/completions`, but some other platform may define their Chat API as `/chat/completions`, `/openai/chat/completions`, `/v2/chat/completions`, etc.

For example, the platform https://data.zhishuyun.com/documents/1bcf3bba-102b-495d-9bba-47cd96717e45 provides Chat Completion 3.5 api with api path `/openai/gpt-3.5`.

So here I added capability of supporting customize API Path, for better support above cases.

Running effect:

<img width="1064" alt="image" src="https://github.com/sparticleinc/chatgpt-google-summary-extension/assets/8678661/9b1a9c96-a75e-4b4a-afc4-c5607377b5c9">

Tested it work:

<img width="1617" alt="image" src="https://github.com/sparticleinc/chatgpt-google-summary-extension/assets/8678661/6f593677-27a8-4ad4-9142-9ca0d705240a">


Please feel free to let me know your thoughts, thanks! 
