### PR TITLE
chore: add https://map.baidu.com to blacklist

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -138,6 +138,7 @@ https://www.peacocktv.com
 https://www.crunchyroll.com
 https://www.funimation.com
 https://www.viki.com
+https://map.baidu.com
 `
 export const APP_TITLE = `Glarity Summary`
 


### PR DESCRIPTION
Glarity disrupts the display style of https://map.baidu.com/, and map websites typically do not require summarization.