### PR TITLE
Fix to TypeError: Cannot read properties of undefined (reading 'config') (setting 'apiKey')

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -102,6 +102,11 @@ export async function getProviderConfigs(): Promise<ProviderConfigs> {
   const randomIndex = configKeys.length > 0 ? Math.floor(Math.random() * configKeys.length) : 0;
   const apiKey = configKeys[randomIndex] ?? ''
   result[configKey].apiKey = apiKey
+  if (!result[configKey]) {
+    result[configKey] = {}
+  }
+  result[configKey].apiKey = apiKey
+
   return {
     provider,
     configs: {

--- a/src/options/ProviderSelect.tsx
+++ b/src/options/ProviderSelect.tsx
@@ -172,6 +172,15 @@ function ProviderSelect() {
   if (query.isLoading) {
     return <Spinner />
   }
+  
+  if (query.error) {
+    return <div>Error loading provider configurations.</div>
+  }
+
+  if (!query.data || !query.data.config) {
+    return <div>No provider configurations found.</div>
+  }
+
   return <ConfigPanel config={query.data!.config} models={models} />
 }
 


### PR DESCRIPTION
Related issue: https://github.com/sparticleinc/chatgpt-google-summary-extension/issues/206

I was able to reproduce the same errors on my setup and can confirm that [dillontkh](https://github.com/sparticleinc/chatgpt-google-summary-extension/issues/206#issuecomment-2117011021)'s code suggestion solves the issue.